### PR TITLE
fix version tag for log4j-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         
         <httpcomponents.version>4.5.11</httpcomponents.version>
         <jackson.version>2.10.2</jackson.version>
-        <log4j.version>2.13</log4j.version>
+        <log4j.version>2.13.1</log4j.version>
         <quartz.version>2.3.2</quartz.version>
         <springframework.version>5.2.3.RELEASE</springframework.version>
         <maven.war.version>3.2.3</maven.war.version>


### PR DESCRIPTION
log4j-api "2.13" seems to have been replaced by" 2.13.0" and "2.13.1" causing a build failure.
See <https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/>